### PR TITLE
Feature/add table totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This is a Vue 2 project with TS using these libraries for component setup:
 ### table row
 On the "Home" page is a table, add a row to this table that displays the totals of the other rows.
 
+I have used as approaced here the computed property to return the sum of each row with the help of the util function totalSum.
+In order to render the data I have leveraged Buefy and used an imported footer component.
+
+
 ### Async/Await
 In the mounted function the data for the table is being fetched, edited and placed in the tableData property with a promise chain. 
 Rewrite this function but instead of chaining promises use async/await to do the exact same. 

--- a/src/components/transferRowFooter.vue
+++ b/src/components/transferRowFooter.vue
@@ -1,0 +1,18 @@
+<template>
+  <th>
+    <span>{{ footerCellText }}</span>
+  </th>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+
+@Component({
+  name: "footerRow",
+})
+export default class footerRow extends Vue {
+  @Prop({ required: true }) footerCellText!: string;
+}
+</script>
+

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,15 +1,30 @@
 <template>
   <div class="home">
     <h1>This is a table with some important data</h1>
-    <b-table :data="tableData" :columns="columns"></b-table>
+    <b-table :data="tableData" :columns="columns">
+      <template #footer>
+        <th key-attribute="footer-label">
+          <span>TOTALS</span>
+        </th>
+        <transferRowFooter key-attribute="totalAuthorizedAmount" :footer-cell-text="totalAuthorizedAmount" />
+        <transferRowFooter key-attribute="totalIssuedAmount" :footer-cell-text="totalIssuedAmount" />
+        <transferRowFooter key-attribute="totalAuthorizedCapital" :footer-cell-text="totalAuthorizedCapital" />
+        <transferRowFooter key-attribute="totalIssuedCapital" :footer-cell-text="totalIssuedCapital" />
+      </template>
+    </b-table>
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { TableData } from "@/types/types";
+import { totalAmount } from "../../utils/helperFunctions";
+import transferRowFooter from "@/components/transferRowFooter.vue";
 
-@Component
+@Component({
+  name: "Home",
+  components: { transferRowFooter },
+})
 export default class Home extends Vue {
   tableData: TableData[] = [];
   columns = [
@@ -35,6 +50,18 @@ export default class Home extends Vue {
     },
   ];
   loading = false;
+  get totalAuthorizedAmount(): number {
+    return totalAmount(this.tableData, "authorizedAmount");
+  }
+  get totalIssuedAmount(): number {
+    return totalAmount(this.tableData, "issuedAmount");
+  }
+  get totalAuthorizedCapital(): number {
+    return totalAmount(this.tableData, "authorizedCapital");
+  }
+  get totalIssuedCapital(): number {
+    return totalAmount(this.tableData, "issuedCapital");
+  }
 
   // mounted works fine if your ide complains about it
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/utils/helperFunctions.ts
+++ b/utils/helperFunctions.ts
@@ -1,0 +1,11 @@
+
+
+import { TableData } from "../src/types/types"
+export const totalAmount = (tableData: TableData[] = [], unit: string): number => {
+  if (!tableData.length) return
+  return tableData
+    .map((data) => data[unit])
+    .reduce((previousValue, currentValue) => previousValue + currentValue, 0);
+}
+
+


### PR DESCRIPTION
This PR brings the following changes:

- add transferRowFooter component to transfers table from the homepage
- add a helper function to reduce duplication code and reusability

## Motivation and Context
As a user, I would like to have the possibility to see the total sum of the other rows.

## From:
![image](https://user-images.githubusercontent.com/53438489/150568121-5d22a3d4-9cf3-4c22-8c93-a8aa40ce3323.png)

##TO
![image](https://user-images.githubusercontent.com/53438489/150568078-5b69e337-2ed7-40cc-ae20-22f4fed3f36e.png)
