### PR TITLE
Feature/add security class

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/src/components/modals/addSecurityClassModal.vue
+++ b/src/components/modals/addSecurityClassModal.vue
@@ -1,0 +1,134 @@
+<template>
+  <section class="section">
+    <div class="modal-card">
+      <div class="modal-card-body">
+        <div class="form__input--layout">
+          <b-field
+            :type="{ 'is-danger': messsage.length }"
+            :message="messsage.length ? messsage : ''"
+            label="Security Class Name"
+          >
+            <b-input maxlength="15" size="is-medium" v-model="securityClassName"></b-input>
+          </b-field>
+          <b-field label="Authorized Amount">
+            <b-numberinput
+              v-model="authorizedAmount"
+              min="1"
+              type="is-light"
+              size="is-medium"
+            >
+            </b-numberinput>
+          </b-field>
+
+          <b-field label="Issued Amount">
+            <b-numberinput
+              v-model="issuedAmount"
+              type="is-light"
+              size="is-medium"
+              min="1"
+            >
+            </b-numberinput>
+          </b-field>
+
+          <b-field label="Authorized Capital">
+            <b-numberinput
+              v-model="authorizedCapital"
+              type="is-light"
+              size="is-medium"
+              min="1"
+            >
+            </b-numberinput>
+          </b-field>
+          <b-field label="Issued Capital">
+            <b-numberinput
+              v-model="issuedCapital"
+              type="is-light"
+              size="is-medium"
+              min="1"
+            >
+            </b-numberinput>
+          </b-field>
+          <b-field label="Nominal Value">
+            <b-numberinput
+              v-model="nominalValue"
+              type="is-light"
+              size="is-medium"
+              min="1"
+            >
+            </b-numberinput>
+          </b-field>
+        </div>
+        <div class="form__btn--layout">
+          <b-button class="btn--close" @click="$emit('close')">Close</b-button>
+          <b-button :disabled="!securityClassName.length" class="btn--submit" @click="submitForm"
+            >Submit</b-button
+          >
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+import { TableData } from "@/types/types";
+
+@Component
+export default class addSecurityClassModal extends Vue {
+  @Prop({ required: false }) securityClassNames!: Array<string>;
+  securityClassName = "";
+  nominalValue = 0;
+  authorizedAmount = 0;
+  issuedAmount = 0;
+  authorizedCapital = 0;
+  issuedCapital = 0;
+  isCardModalActive = false;
+  messsage = "";
+
+  submitForm(): void {
+    const securityClass: TableData = {
+      id: JSON.stringify(Math.random()),
+      name: this.securityClassName,
+      nominalValue: this.nominalValue,
+      authorizedAmount: this.authorizedAmount,
+      issuedAmount: this.issuedAmount,
+      authorizedCapital: this.authorizedCapital,
+      issuedCapital: this.issuedCapital,
+    };
+
+    const duplicateRecordName = this.securityClassNames.find((name) => name === securityClass.name);
+    if (duplicateRecordName) {
+      this.messsage = "Security Class already registered";
+      return;
+    }
+    this.$emit("submit", securityClass);
+    this.$emit("close");
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.form__input--layout {
+  margin: 0 2rem;
+}
+.form__btn--layout {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10rem;
+  button {
+    padding: 1rem 2rem;
+    border-radius: 4px;
+  }
+  .btn--submit {
+    background: rgb(13, 189, 174);
+    color: rgb(255, 255, 255);
+  }
+  .btn--close {
+    border-color: rgb(41, 212, 198);
+    border: 2px solid;
+    color: rgb(13, 189, 174);
+  }
+}
+</style>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -17,6 +17,9 @@ export default new Vuex.Store({
   mutations: {
     setTableData(state, data) {
       state.tableResources = data
+    },
+    setSecurityClass(state, data: TableData): void {
+      state.tableResources = [...state.tableResources, data]
     }
   },
   actions: {
@@ -28,5 +31,13 @@ export default new Vuex.Store({
         console.log('Cannot getTableData', error);
       }
     },
+    async addSecurityClass({ commit }, securityClass) {
+      try {
+        const { data }: { data: TableData[] } = await api.post(`/resources`, securityClass)
+        commit('setSecurityClass', data)
+      } catch (error) {
+        console.log('Cannot addSecurityClass', error);
+      }
+    }
   },
 });

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,17 +1,26 @@
 <template>
   <div class="home">
     <h1>This is a table with some important data</h1>
-    <b-table :data="tableResources" :columns="columns">
-      <template #footer>
-        <th key-attribute="footer-label">
-          <span>TOTALS</span>
-        </th>
-        <transferRowFooter key-attribute="totalAuthorizedAmount" :footer-cell-text="totalAuthorizedAmount" />
-        <transferRowFooter key-attribute="totalIssuedAmount" :footer-cell-text="totalIssuedAmount" />
-        <transferRowFooter key-attribute="totalAuthorizedCapital" :footer-cell-text="totalAuthorizedCapital" />
-        <transferRowFooter key-attribute="totalIssuedCapital" :footer-cell-text="totalIssuedCapital" />
-      </template>
-    </b-table>
+    <b-button @click="onAddSecurityClass" size="is-small" class="btn--add" icon-left="plus">
+      Security Class
+    </b-button>
+    <div v-if="tableResources">
+      <b-table :data="tableResources" :columns="columns">
+        <template #footer>
+          <th key-attribute="footer-label">
+            <span>TOTALS</span>
+          </th>
+          <transferRowFooter key-attribute="totalAuthorizedAmount" :footer-cell-text="totalAuthorizedAmount"
+          />
+          <transferRowFooter key-attribute="totalIssuedAmount" :footer-cell-text="totalIssuedAmount"
+          />
+          <transferRowFooter key-attribute="totalAuthorizedCapital" :footer-cell-text="totalAuthorizedCapital"
+          />
+          <transferRowFooter key-attribute="totalIssuedCapital" :footer-cell-text="totalIssuedCapital"
+          />
+        </template>
+      </b-table>
+    </div>
   </div>
 </template>
 
@@ -19,7 +28,8 @@
 import { Component, Vue } from "vue-property-decorator";
 import { mapActions, mapGetters } from "vuex";
 import { TableData } from "@/types/types";
-import { totalAmount } from "../../utils/helperFunctions";
+import { totalAmount } from "@/../utils/helperFunctions";
+import addSecurityClassModal from "@/components/modals/addSecurityClassModal.vue";
 import transferRowFooter from "@/components/transferRowFooter.vue";
 
 @Component({
@@ -33,15 +43,14 @@ import transferRowFooter from "@/components/transferRowFooter.vue";
   },
 })
 export default class Home extends Vue {
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   async created() {
     await this.getTableData();
   }
   getTableData!: () => any;
+  addSecurityClass!: () => any;
   tableResources!: () => any;
-  
-  tableData: TableData[] = [];
   columns = [
     {
       label: "Security class",
@@ -65,6 +74,31 @@ export default class Home extends Vue {
     },
   ];
   loading = false;
+
+  onAddSecurityClass(): void {
+    this.$buefy.modal.open({
+      parent: this,
+      component: addSecurityClassModal,
+      hasModalCard: true,
+      width: 900,
+      trapFocus: true,
+      scroll: "keep",
+      ariaModal: true,
+      customClass: "card-form-modal",
+      canCancel: ["outside"],
+      props: {
+        securityClassNames: this.securityClassNames,
+      },
+      events: {
+        submit: (record: TableData): void => {
+          this.addSecurityClass(record);
+        },
+      },
+    });
+  }
+  get securityClassNames(): Array<string> {
+    return this.tableResources.map((securityName: string) => securityName.name);
+  }
   get totalAuthorizedAmount(): number {
     return totalAmount(this.tableResources, "authorizedAmount");
   }
@@ -77,68 +111,16 @@ export default class Home extends Vue {
   get totalIssuedCapital(): number {
     return totalAmount(this.tableResources, "issuedCapital");
   }
-
-  // mounted works fine if your ide complains about it
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  // mounted() {
-  //   this.getData()
-  //     .then((data: TableData[]) => {
-  //       this.loading = true;
-  //       return data.map((dataItem: TableData) => {
-  //         return {
-  //           ...dataItem,
-  //           randomNumber: Math.random(),
-  //         };
-  //       });
-  //     })
-  //     .then((data: TableData[]) => {
-  //       this.tableData = data;
-  //       this.loading = false;
-  //     })
-  //     .catch((error) => {
-  //       console.log(error, "This is not good");
-  //     });
-  // }
-
-  // async getData(): Promise<TableData[]> {
-  //   return [
-  //     {
-  //       id: "42f2462d-49d0-4e91-8fe1-de2e656b0f06",
-  //       name: "Series A",
-  //       nominalValue: 5,
-  //       authorizedAmount: 1500,
-  //       issuedAmount: 500,
-  //       authorizedCapital: 7550,
-  //       issuedCapital: 2500,
-  //     },
-  //     {
-  //       id: "42f2462d-49d0-4e91-8fe1-de2e656b0f06",
-  //       name: "Series B",
-  //       nominalValue: 10,
-  //       authorizedAmount: 15000,
-  //       issuedAmount: 5000,
-  //       authorizedCapital: 150000,
-  //       issuedCapital: 50000,
-  //     },
-  //     {
-  //       id: "fd78c11b-e3d2-455a-99b0-49907a75c463",
-  //       name: "Series C",
-  //       nominalValue: 1,
-  //       authorizedAmount: 96876,
-  //       issuedAmount: 61760,
-  //       authorizedCapital: 96876,
-  //       issuedCapital: 61760,
-  //     },
-  //     {
-  //       id: "d8654cb0-8986-4fbc-b969-025e514cb934",
-  //       name: "Series D",
-  //       nominalValue: 1,
-  //       authorizedAmount: 10110,
-  //       issuedAmount: 1100,
-  //       authorizedCapital: 10110,
-  //       issuedCapital: 1100,
-  //     },
-  //   ];
-  // }
 }
 </script>
+<style scoped lang="scss">
+.btn--add {
+  background: rgb(13, 189, 174);
+  color: rgb(255, 255, 255);
+  &:hover {
+    background: rgb(255, 255, 255);
+    color: rgb(13, 189, 174);
+    border: 2px solid rgb(13, 189, 174);
+  }
+}
+</style>


### PR DESCRIPTION
## Motivation and Context
As a user, I would like to have the ability to register a new security class through an interface.

Registering a new security class implies filling the following fields:
- security class name
- authorized amount
- issued amount
- authorized capital
- issued capital
- nominal value


## CHANGES
- add Buefy modal component for registering a new security class
- add store post method
- class name validator
- it immediately updates table data and total row sum

![image](https://user-images.githubusercontent.com/53438489/150579140-0bdf76d9-52ed-4676-922d-ff5355a976df.png)

![image](https://user-images.githubusercontent.com/53438489/150579176-97ac002b-36ee-4eba-bf33-326829c6d564.png)

