### PR TITLE
[Bugfix] Transfers Button

### DIFF
--- a/src/components/transferRow.vue
+++ b/src/components/transferRow.vue
@@ -21,7 +21,7 @@
           <span class="second-address">46th Ave, Woodside, NY 11101 Woodside</span>
           <div :style="`border: 2px solid ${randomColors}`" class="circle bottom-circle" />
         </div>
-        <!-- <span v-if="transfer.forgottenProperty">{{ transfer.forgottenProperty }}</span> -->
+          <span style="color:red; font-weight:600; font-size:15px;" v-if="transfer.forgottenProperty">{{ transfer.forgottenProperty }}</span>
       </div>
       <div class="transfer--footer">
         <div>

--- a/src/views/Transfers.vue
+++ b/src/views/Transfers.vue
@@ -36,10 +36,10 @@ export default class Transfers extends Vue {
       // custom search, should be improved upon
       const searchArray: Transaction[] = [];
       this.transfers.forEach((transfer: Transaction) => {
-        if (
-          transfer.recordDate?.toLowerCase().includes(this.searchTerms.toLowerCase())
-        ) {
-          searchArray.push(transfer);
+       if (
+         transfer.recordDate?.toLowerCase().includes(this.searchTerms.toLowerCase())
+       ) { 
+         searchArray.push(transfer);       
         }
       });
       return searchArray;
@@ -48,8 +48,13 @@ export default class Transfers extends Vue {
   }
 
   updateTransfers(): void {
-    this.transfers.forEach((transfer) => {
-     transfer.forgottenProperty = `Important data: ${(Math.random() * 100000000).toString().slice(1, 8)}`;
+    this.transfers.forEach((transfer: Transaction) => {
+      const forgottenPropertyValue = `Important data: ${(Math.random() * 100000000).toString().slice(1, 8)}`;
+      Vue.set(
+        transfer,
+        "forgottenProperty",
+        forgottenPropertyValue
+      );
     });
 
     this.transfers[0] = {


### PR DESCRIPTION
## Motivation and Context
The update transfers function is missing root level reactivity.

This PR fixes the following:
Update transfer lists on click event.

`Problem`
The component state is not updating. Vue doesn't detect changes if the property wasn't initially declared, nor if deep level changes occur(adding a member to an array).

`Solution`
Use an instance method in order to trigger the Vue reactivity system.


##forgoten property
![image](https://user-images.githubusercontent.com/53438489/150606181-21324801-c4ce-4313-b34e-14149f40a5a1.png)


